### PR TITLE
feat:관리자페이지에서 손님들의 주문목록 조회하기

### DIFF
--- a/src/main/java/com/coffee/controller/AdminOrderController.java
+++ b/src/main/java/com/coffee/controller/AdminOrderController.java
@@ -1,6 +1,6 @@
 package com.coffee.controller;
 
-import com.coffee.domain.Order;
+import com.coffee.dto.OrderResponse;
 import com.coffee.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -17,8 +17,9 @@ public class AdminOrderController {
 
     @GetMapping("/admin/orders")
     public String showOrderList(Model model) {
-        List<Order> orders = orderService.getAllOrders();
+        List<OrderResponse> orders = orderService.getAllOrders();
         model.addAttribute("orders", orders);
         return "admin/orderList";
     }
+
 }

--- a/src/main/java/com/coffee/controller/AdminOrderController.java
+++ b/src/main/java/com/coffee/controller/AdminOrderController.java
@@ -1,0 +1,24 @@
+package com.coffee.controller;
+
+import com.coffee.domain.Order;
+import com.coffee.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class AdminOrderController {
+
+    private final OrderService orderService;
+
+    @GetMapping("/admin/orders")
+    public String showOrderList(Model model) {
+        List<Order> orders = orderService.getAllOrders();
+        model.addAttribute("orders", orders);
+        return "admin/orderList";
+    }
+}

--- a/src/main/java/com/coffee/service/OrderService.java
+++ b/src/main/java/com/coffee/service/OrderService.java
@@ -87,4 +87,8 @@ public class OrderService {
         return orderProduct;
     }
 
+    //관리자용 주문 목록 조회ㅏ
+    public List<Order> getAllOrders() {
+        return orderRepository.findAll();
+    }
 }

--- a/src/main/java/com/coffee/service/OrderService.java
+++ b/src/main/java/com/coffee/service/OrderService.java
@@ -87,8 +87,11 @@ public class OrderService {
         return orderProduct;
     }
 
-    //관리자용 주문 목록 조회ㅏ
-    public List<Order> getAllOrders() {
-        return orderRepository.findAll();
+   //관리자용 주문 목록 조회
+    public List<OrderResponse> getAllOrders() {
+        List<Order> orders = orderRepository.findAll();
+        return orders.stream()
+                .map(OrderResponse::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/resources/templates/admin/orderList.html
+++ b/src/main/resources/templates/admin/orderList.html
@@ -163,7 +163,7 @@
       </thead>
       <tbody>
       <tr th:each="order : ${orders}" th:class="${'status-' + #strings.toLowerCase(order.deliveryStatus)}">
-        <td th:text="${order.id}"></td>
+        <td th:text="${order.orderId}"></td>
         <td th:text="${order.email}"></td>
         <td th:text="${order.address}"></td>
         <td th:text="${order.postcode}"></td>

--- a/src/main/resources/templates/admin/orderList.html
+++ b/src/main/resources/templates/admin/orderList.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>주문 목록</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+    }
+
+    .navbar {
+      background-color: darkseagreen;
+      overflow: hidden;
+      margin-bottom: 20px;
+    }
+
+    .navbar a {
+      float: left;
+      display: block;
+      color: white;
+      text-align: center;
+      padding: 14px 16px;
+      text-decoration: none;
+    }
+
+    .navbar a:hover {
+      background-color: #555;
+    }
+
+    .navbar a.active {
+      background-color: #4CAF50;
+    }
+
+    .container {
+      padding: 0 20px;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 20px;
+    }
+
+    .logout-btn {
+      padding: 6px 12px;
+      background-color: #f44336;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    .logout-btn:hover {
+      background-color: #d32f2f;
+    }
+
+    .back-btn {
+      display: inline-block;
+      margin-bottom: 15px;
+      padding: 8px 12px;
+      background-color: #2196F3;
+      color: white;
+      text-decoration: none;
+      border-radius: 5px;
+    }
+
+    .back-btn:hover {
+      background-color: #0b7dda;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+
+    th, td {
+      padding: 10px;
+      border: 1px solid #ccc;
+      text-align: center;
+    }
+
+    .status-pending {
+      background-color: #ffecb3;
+    }
+
+    .status-shipped {
+      background-color: #c8e6c9;
+    }
+
+    .status-delivered {
+      background-color: #bbdefb;
+    }
+
+    .status-cancelled {
+      background-color: #ffcdd2;
+    }
+
+    .view-details {
+      display: inline-block;
+      padding: 4px 8px;
+      background-color: #4CAF50;
+      color: white;
+      text-decoration: none;
+      border-radius: 3px;
+    }
+
+    .view-details:hover {
+      background-color: #45a049;
+    }
+
+    .empty-list {
+      text-align: center;
+      padding: 40px;
+      background-color: #f9f9f9;
+      border-radius: 8px;
+      margin-top: 20px;
+    }
+
+    .empty-list p {
+      color: #666;
+      font-size: 18px;
+      margin-bottom: 20px;
+    }
+
+    .empty-list .emoji {
+      font-size: 48px;
+      margin-bottom: 20px;
+      display: block;
+    }
+  </style>
+</head>
+<body>
+
+<div class="navbar">
+  <a href="/coffee">커피 메뉴</a>
+  <a href="/admin/orderList" class="active">주문 목록</a>
+</div>
+
+<div class="container">
+  <div class="header">
+    <h1>주문 목록</h1>
+    <form th:action="@{/logout}" method="post">
+      <button type="submit" class="logout-btn">로그아웃</button>
+    </form>
+  </div>
+
+  <div th:if="${not #lists.isEmpty(orders)}">
+    <table>
+      <thead>
+      <tr>
+        <th>주문 ID</th>
+        <th>이메일</th>
+        <th>주소</th>
+        <th>우편번호</th>
+        <th>주문일시</th>
+        <th>배송상태</th>
+        <th>총 금액</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr th:each="order : ${orders}" th:class="${'status-' + #strings.toLowerCase(order.deliveryStatus)}">
+        <td th:text="${order.id}"></td>
+        <td th:text="${order.email}"></td>
+        <td th:text="${order.address}"></td>
+        <td th:text="${order.postcode}"></td>
+        <td th:text="${#temporals.format(order.createdAt, 'yyyy-MM-dd HH:mm')}"></td>
+        <td th:text="${order.deliveryStatus}"></td>
+        <td th:text="${#numbers.formatInteger(order.totalPrice, 0, 'COMMA') + '원'}"></td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div th:if="${#lists.isEmpty(orders)}" class="empty-list">
+    <span class="emoji">📭</span>
+    <p>아직 접수된 주문이 없습니다.</p>
+    <a href="/coffee" class="back-btn">커피 메뉴로 돌아가기</a>
+  </div>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/coffee/list.html
+++ b/src/main/resources/templates/coffee/list.html
@@ -4,22 +4,57 @@
   <meta charset="UTF-8">
   <title>커피 메뉴</title>
   <style>
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-top: 20px;
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
     }
 
-    th, td {
-      padding: 10px;
-      border: 1px solid #ccc;
+    .navbar {
+      background-color: darkseagreen;
+      overflow: hidden;
+      margin-bottom: 20px;
+    }
+
+    .navbar a {
+      float: left;
+      display: block;
+      color: white;
       text-align: center;
+      padding: 14px 16px;
+      text-decoration: none;
     }
 
-    img {
-      width: 100px;
-      height: 100px;
-      object-fit: cover;
+    .navbar a:hover {
+      background-color: #555;
+    }
+
+    .navbar a.active {
+      background-color: #4CAF50;
+    }
+
+    .container {
+      padding: 0 20px;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 20px;
+    }
+
+    .logout-btn {
+      padding: 6px 12px;
+      background-color: #f44336;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    .logout-btn:hover {
+      background-color: #d32f2f;
     }
 
     .add-btn {
@@ -36,6 +71,24 @@
       background-color: #45a049;
     }
 
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+
+    th, td {
+      padding: 10px;
+      border: 1px solid #ccc;
+      text-align: center;
+    }
+
+    img {
+      width: 100px;
+      height: 100px;
+      object-fit: cover;
+    }
+
     .no-image {
       font-style: italic;
       color: #999;
@@ -44,46 +97,56 @@
 </head>
 <body>
 
-<h1>커피 메뉴 목록</h1>
+<div class="navbar">
+  <a href="/coffee" class="active">커피 메뉴</a>
+  <a href="/admin/orders">주문 목록</a>
+</div>
 
-<a th:href="@{/coffee/add}" class="add-btn">+ 새 커피 추가</a>
+<div class="container">
+  <div class="header">
+    <h1>커피 메뉴 목록</h1>
+    <form th:action="@{/logout}" method="post">
+      <button type="submit" class="logout-btn">로그아웃</button>
+    </form>
+  </div>
 
-<table>
-  <thead>
-  <tr>
-    <th>이미지</th>
-    <th>이름</th>
-    <th>가격</th>
-    <th>설명</th>
-    <th>수정</th>
-    <th>삭제</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr th:each="product : ${products}">
-    <td>
-      <!-- 이미지 경로가 있을 경우 표시 -->
-      <img th:if="${product.imagePath != null and !#strings.isEmpty(product.imagePath)}"
-           th:src="@{/uploaded-images/{image}(image=${product.imagePath})}"/>
-      <!-- 이미지 경로가 없을 경우 표시 -->
-      <span th:if="${product.imagePath == null or #strings.isEmpty(product.imagePath)}"
-            class="no-image">이미지 없음</span>
-    </td>
-    <td th:text="${product.name}">이름</td>
-    <td th:text="${product.price} + '원'">가격</td>
-    <td th:text="${product.description}">설명</td>
-    <td>
-      <a th:href="@{'/coffee/edit/' + ${product.id}}">수정</a>
-    </td>
-    <td>
-      <form th:action="@{'/coffee/delete/' + ${product.id}}" method="post"
-            th:onsubmit="return confirm('정말 삭제하시겠습니까?');">
-        <button type="submit">삭제</button>
-      </form>
-    </td>
-  </tr>
-  </tbody>
-</table>
+  <a th:href="@{/coffee/add}" class="add-btn">+ 새 커피 추가</a>
+
+  <table>
+    <thead>
+    <tr>
+      <th>이미지</th>
+      <th>이름</th>
+      <th>가격</th>
+      <th>설명</th>
+      <th>수정</th>
+      <th>삭제</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="product : ${products}">
+      <td>
+        <img th:if="${product.imagePath != null and !#strings.isEmpty(product.imagePath)}"
+             th:src="@{/uploaded-images/{image}(image=${product.imagePath})}"/>
+        <span th:if="${product.imagePath == null or #strings.isEmpty(product.imagePath)}"
+              class="no-image">이미지 없음</span>
+      </td>
+      <td th:text="${product.name}">이름</td>
+      <td th:text="${product.price} + '원'">가격</td>
+      <td th:text="${product.description}">설명</td>
+      <td>
+        <a th:href="@{'/coffee/edit/' + ${product.id}}">수정</a>
+      </td>
+      <td>
+        <form th:action="@{'/coffee/delete/' + ${product.id}}" method="post"
+              th:onsubmit="return confirm('정말 삭제하시겠습니까?');">
+          <button type="submit">삭제</button>
+        </form>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
feat:관리자페이지에서 손님들의 주문목록 조회하기

## 스크린샷
<img width="1716" alt="스크린샷 2025-04-24 오후 5 17 57" src="https://github.com/user-attachments/assets/2af06458-d069-4631-a2c3-80f042bef7bd" />
메뉴바를 통해서 메뉴 추가 페이지랑, 주문조회 목록 페이지 둘 중에서 조회가 가능하도록 구현 


<img width="1712" alt="스크린샷 2025-04-24 오후 5 18 07" src="https://github.com/user-attachments/assets/61a1029c-8cee-4216-a5c0-41da9808f193" />
주문 목록 없을 때는 이렇게 보이도록


<img width="1712" alt="스크린샷 2025-04-24 오후 5 19 55" src="https://github.com/user-attachments/assets/faae7cc0-2b83-4767-9361-09775c62938a" />
주문목록 있을 때는 이렇게 보인다.

## 주의사항

Closes #{이슈 번호}