### PR TITLE
feat:저장이미지뜨도록수정

### DIFF
--- a/src/main/resources/templates/orderForm.html
+++ b/src/main/resources/templates/orderForm.html
@@ -142,12 +142,21 @@
       <ul class="products" id="product-list">
         <li th:each="product : ${products}"
             th:attr="data-name=${product.name}, data-price=${product.price}, data-id=${product.id}">
-          <img src="https://i.imgur.com/HKOFQYa.jpeg" alt="기본 이미지">
-          <div class="col-info">
-            <div class="category">커피</div>
-            <div class="name" th:text="${product.name}">상품명</div>
+          <div>
+            <img th:if="${product.imagePath != null and !#strings.isEmpty(product.imagePath)}"
+                 th:src="@{/uploaded-images/{image}(image=${product.imagePath})}" alt="제품 이미지" />
+            <span th:if="${product.imagePath == null or #strings.isEmpty(product.imagePath)}"
+                  class="no-image">이미지 없음</span>
           </div>
-          <div class="price" th:text="${product.price + '원'}">가격</div>
+          <div class="col-info">
+            <!-- 상품명 자리 → product.name -->
+            <div class="name" th:text="${product.name}">상품 이름</div>
+            <!-- 설명 자리 → product.description -->
+            <div class="category" th:text="${product.description}">상품 설명</div>
+          </div>
+          <!-- 가격 자리 → product.price -->
+          <div class="price" th:text="${product.price}">가격</div>
+
           <div class="action">
             <button class="btn btn-sm btn-outline-dark add-btn">추가</button>
           </div>


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용
기존의 기본 이미지 데이터에서 각자 관리자 페이지에서 저장한 메뉴의 이미지와, 이름, 설명을 불러와서 볼 수 있도록 수정하였습니다.

## 스크린샷
<img width="1196" alt="스크린샷 2025-04-25 오후 4 03 50" src="https://github.com/user-attachments/assets/e1cff247-91ec-42bf-b115-597aebe68ab2" />

## 주의사항

Closes #{이슈 번호}